### PR TITLE
docs: require owner sign-off for frontend-affecting changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# CLAUDE.md
+
+Repo-specific guidance for Claude Code. Cross-service rules live in the root `CLAUDE.md`
+of the `rz-workspace` umbrella checkout.
+
+## Never break the frontend
+
+This package's DTOs and Enums are serialized into the API responses of **every** Laravel
+service, so the blast radius of a change here is the whole system — `rz-frontend`
+included.
+
+Before renaming or removing an Enum case, changing an Enum's backing value, or changing a
+DTO's property names or types → grep `rz-frontend/src` for the value. Any hit means the
+change is frontend-affecting: **STOP and get an owner decision** before shipping.
+Additive-only changes (a new Enum case, a new optional DTO property) are fine.
+
+Dependent services still need `composer update rz-common` after any change here.
+
+Full rule: root `CLAUDE.md` → "Never break the frontend".


### PR DESCRIPTION
Adds a standing rule: **a change that alters what `rz-frontend` consumes must not ship
without an owner decision.**

The full rule lives in the umbrella root `CLAUDE.md`; this repo gets the section tailored
to the contract *this* service actually exposes to the frontend. The check is concrete —
grep `rz-frontend/src` for the field, route, token, or channel before touching it; any
hit means stop and ask, rather than "also update the frontend" unilaterally. Additive
changes (a new optional field, a new endpoint) are explicitly not breaking, so normal
feature work is unaffected.

Docs only — no runtime behavior to validate beyond CI going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
